### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -183,7 +183,7 @@ jobs:
           account_key: ${{ secrets.GCLOUD_KEY }}
 
       - name: "3. Build and publish docker to GCR"
-        uses: elgohr/Publish-Docker-Github-Action@2.14
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: eu.gcr.io/unit8-product/u8timeseries
           username: ${{ steps.gcloud.outputs.username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore